### PR TITLE
Adding this repo for artifact com.github.everit-org.json-schema:org.everit.json.schema:jar:1.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,10 @@
                 <enabled>false</enabled>
             </releases>
         </repository>
+        <repository>
+            <id>mulesoft</id>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
+        </repository>
     </repositories>
 
     <properties>


### PR DESCRIPTION
Got this error while trying to build it in local:
[ERROR] Failed to execute goal on project light-scheduler: Could not resolve dependencies for project com.networkn
t:light-scheduler:jar:2.0.31-SNAPSHOT: Could not find artifact com.github.everit-org.json-schema:org.everit.json.schema:jar:1.12.1 in confluent (https://packages.confluent.io/maven/) -> [Help 1]

Hence adding the maven repo that contains this artifact.